### PR TITLE
[Fix] Start production script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "env-cmd -f .env.development nodemon -r tsconfig-paths/register ./src/index.ts",
-    "start:production": "env-cmd -f .env.production node -r tsconfig-paths/register dist/index.js",
+    "start:production": "env-cmd -f .env.production node -r module-alias/register dist/index.js",
     "start:dist": "env-cmd -f .env.development node -r module-alias/register dist/index.js",
     "build": "tsc",
     "lint": "tsc --noEmit && eslint --fix 'src/**/*.ts'"


### PR DESCRIPTION
## Description

Fix the `start:production` script to use `module-alias` instead of `tsconfig-paths`
